### PR TITLE
Employee adding form and data display

### DIFF
--- a/components/employees/EmployeeData.module.scss
+++ b/components/employees/EmployeeData.module.scss
@@ -1,0 +1,16 @@
+.wrapper {
+  display: flex;
+
+  :global(.table-container) {
+    flex: 1;
+    margin-right: 1em;
+  }
+
+  .image {
+    width: 300px;
+
+    img {
+      max-width: 100%;
+    }
+  }
+}

--- a/components/employees/EmployeeData.tsx
+++ b/components/employees/EmployeeData.tsx
@@ -1,0 +1,86 @@
+import styles from './EmployeeData.module.scss';
+import { EmployeeDataFormFields } from './EmployeeForm';
+
+export interface Employee extends Omit<EmployeeDataFormFields, 'photo' | 'idScan' | 'authCode'> {
+  employeeId?: string;
+  uniqueId?: string;
+
+  photo: string;
+  idScan: string;
+}
+
+const EmployeeData = ({ employee }: { employee: Employee }) => {
+  const data = [
+    {
+      id: 'Name',
+      value: `${employee.firstName}, ${employee.lastName} ${employee.middleName || ''}`,
+    },
+    {
+      id: 'Identification',
+      value: employee.identification
+    },
+    {
+      id: 'ID',
+      value: employee.id
+    },
+    {
+      id: 'Department',
+      value: employee.department
+    },
+    {
+      id: 'Mobile',
+      value: employee.mobile
+    },
+    {
+      id: 'Email address',
+      value: employee.email
+    },
+    {
+      id: 'Blood group',
+      value: employee.bloodGroup
+    },
+    {
+      id: 'Date of birth',
+      value: employee.dob
+    },
+    {
+      id: 'Joining date',
+      value: employee.joiningDate
+    },
+    {
+      id: 'Marital status',
+      value: employee.maritalStatus
+    },
+    {
+      id: 'Address',
+      value: employee.address
+    },
+    {
+      id: 'Designation',
+      value: employee.designation
+    },
+    {
+      id: 'ID scan',
+      value: <a href={employee.idScan} target="_blank">(view attachment)</a>
+    }
+  ];
+
+  return (
+    <div className={styles.wrapper}>
+      <div className="table-container">
+        {data.map(entry => (
+          <div className="row" key={entry.id}>
+            <div className="column key">{entry.id}</div>
+            <div className="column">{entry.value}</div>
+          </div>
+        ))}
+      </div>
+
+      {employee.photo && <div className={styles.image}>
+        <img src={employee.photo} alt={employee.id} />
+      </div>}
+    </div>
+  );
+};
+
+export default EmployeeData;

--- a/components/employees/EmployeeForm.tsx
+++ b/components/employees/EmployeeForm.tsx
@@ -1,0 +1,200 @@
+import { useRouter } from 'next/router';
+import { ChangeEvent, FormEvent, useState } from 'react';
+
+import clsx from 'clsx';
+
+import LoadingSpinner from '../loading-spinner/LoadingSpinner';
+
+export type EmployeeMaritalStatus = 'Single'
+| 'Married'
+| 'Widowed'
+| 'Divorced'
+| 'Separated'
+| 'Domestic partnership'
+| 'Complicated';
+
+const MARITAL_STATUSES: EmployeeMaritalStatus[] = [
+  'Single',
+  'Married',
+  'Widowed',
+  'Divorced',
+  'Separated',
+  'Domestic partnership',
+  'Complicated'
+];
+
+export interface EmployeeDataFormFields {
+  firstName: string;
+  middleName?: string;
+  lastName: string;
+  identification: string;
+  id: string;
+  department: string;
+  mobile: string;
+  email: string;
+  bloodGroup: string;
+  dob: string;
+  joiningDate: string;
+  maritalStatus: EmployeeMaritalStatus;
+  address: string;
+  designation: string;
+  photo: File | null;
+  idScan: File | null;
+
+  authCode: string;
+}
+
+export interface EmployeeDataServerResponse {
+  code: number;
+  message: string;
+  data?: {
+    employee_id?: string;
+    unique_id?: string;
+  };
+}
+
+export interface EmployeeFormParams {
+  send(fields: EmployeeDataFormFields): Promise<EmployeeDataServerResponse>;
+}
+
+const EmployeeForm = ({ send }: EmployeeFormParams) => {
+  const [ employeeData, setEmployeeData ] = useState<EmployeeDataFormFields>({
+    firstName: '',
+    middleName: '',
+    lastName: '',
+    identification: '',
+    id: '',
+    department: '',
+    mobile: '',
+    email: '',
+    bloodGroup: '',
+    dob: '',
+    joiningDate: '',
+    maritalStatus: 'Single',
+    address: '',
+    designation: '',
+    photo: null,
+    idScan: null,
+
+    authCode: ''
+  });
+
+  const [ error, setError ] = useState('');
+  const [ sending, setSending ] = useState(false);
+
+  const [ jiggle, setJiggle ] = useState(false);
+
+  const router = useRouter();
+
+  const update = (field: string) => {
+    return (e: ChangeEvent<HTMLInputElement | HTMLSelectElement>) => setEmployeeData({
+      ...employeeData,
+      [`${field}`]: (e.currentTarget instanceof HTMLInputElement && e.currentTarget.files?.length)
+        ? e.currentTarget.files[0]
+        : e.currentTarget.value
+    });
+  };
+
+  const jiggleForm = () => {
+    setJiggle(true);
+
+    setTimeout(() => {
+      setJiggle(false);
+    }, 500);
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+
+    setSending(true);
+    setError('');
+
+    try {
+      const res = await send(employeeData);
+      setSending(false);
+
+      if (res.code === 0) {
+        router.push(`/employees/${res.data.employee_id}`);
+        return;
+      }
+
+      setError(res.message ?? 'Internal Server Error');
+    } catch (err) {
+      console.error(err);
+      setError('Internal Server Error');
+    }
+
+    jiggleForm();
+    setSending(false);
+  };
+
+  const inputs = Object.keys(employeeData)
+    .map(field => {
+      if (field === 'maritalStatus') {
+        return (
+          <div className="input-group" key={field}>
+            <label htmlFor={field}>{field}:</label>
+            <select
+              name={field}
+              id={field}
+              disabled={sending}
+              onChange={update(field)}
+            >
+              {MARITAL_STATUSES.map(status => (
+                <option key={status} value={status}>{status}</option>
+              ))}
+            </select>
+          </div>
+        );
+      }
+
+      if ([ 'photo', 'idScan' ].includes(field)) {
+        return (
+          <div className="input-group" key={field}>
+            <label htmlFor={field}>{field}</label>
+            <input
+              type="file"
+              multiple={false}
+              name={field}
+              id={field}
+              disabled={sending}
+              onChange={update(field)}
+            />
+          </div>
+        );
+      }
+
+      const inputType = [ 'dob', 'joiningDate' ].includes(field)
+        ? 'date'
+        : field === 'authCode' ? 'password' : 'text';
+
+      return (
+        <div className="input-group" key={field}>
+          <label htmlFor={field}>{field}</label>
+          <input
+            type={inputType}
+            name={field}
+            id={field}
+            disabled={sending}
+            onChange={update(field)}
+          />
+        </div>
+      );
+    });
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div className={clsx({ jiggle })}>
+        {inputs}
+
+        <div className="input-group buttons">
+          <button type="submit" className="single-button" disabled={sending}>Submit</button>
+          {sending && <LoadingSpinner color="#fff" />}
+          {error.length > 0 && <small className="form-error">{error}</small>}
+        </div>
+      </div>
+    </form>
+  );
+};
+
+export default EmployeeForm;

--- a/components/modal/Modal.tsx
+++ b/components/modal/Modal.tsx
@@ -32,8 +32,9 @@ const Modal = ({ display, onClose, children }) => {
       >
         <div className={styles.modal}>
           <div className={styles.close} onClick={onClose}>
-          <FontAwesomeIcon icon={faTimes} className={styles.alignFix}/>
+            <FontAwesomeIcon icon={faTimes} className={styles.alignFix}/>
           </div>
+
           {children}
         </div>
 

--- a/pages/api/employees/[id].ts
+++ b/pages/api/employees/[id].ts
@@ -1,0 +1,46 @@
+// This is a test API endpoints for testing employee data fetching. It tries to
+// replicate the live API's expected behavior and responses. There is a
+// designated server key that needs to match whatever the user provides in the
+// `secret` query paramter, otherwise it will return 403.
+//
+// Note that the security of this process should be greatly improved on the live
+// API.
+//
+// POST /api/employees/:id?secret=:secret
+
+import { NextApiRequest, NextApiResponse } from 'next';
+
+import * as path from 'path';
+import * as fs from 'fs';
+
+const SERVER_SECRET = 'are-ya-winning-watson'; // devserver secret
+const DB_PATH = path.join(process.cwd(), 'temp', 'employees.json');
+
+export default function get(req: NextApiRequest, res: NextApiResponse) {
+  const { id, secret } = req.query;
+
+  if (secret !== SERVER_SECRET) {
+    return res.status(403).json({
+      code: 403,
+      message: 'Incorrect server secret.'
+    });
+  }
+
+  const db = fs.existsSync(DB_PATH)
+    ? JSON.parse(fs.readFileSync(DB_PATH, { encoding: 'utf8' }))
+    : [];
+
+  const targetEmployee = db.find(employee => employee.employeeId === id);
+  if (!targetEmployee) {
+    return res.status(404).json({
+      code: 404,
+      message: 'Employee not found.'
+    });
+  }
+
+  return res.json({
+    code: 0,
+    message: 'success',
+    data: targetEmployee
+  });
+};

--- a/pages/api/employees/index.ts
+++ b/pages/api/employees/index.ts
@@ -1,0 +1,113 @@
+// This is a test API endpoint for testing the employee adding form. It tries to
+// replicate live API's expected behavior and responses. There is a designated
+// server key that needs to match whatever the user provides, otherwise the data
+// will not be added to the database.
+//
+// Note that the security of this process should be greatly improved on the live
+// API.
+//
+// POST /api/employees
+
+import { Employee } from '@/components/employees/EmployeeData';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+import * as path from 'path';
+import * as fs from 'fs';
+
+type EmployeeWithAuthCode = Employee & { authCode: string };
+
+const SERVER_SECRET = 'are-ya-winning-watson'; // devserver secret
+const DB_PATH = path.join(process.cwd(), 'temp', 'employees.json');
+
+const randomString = (len: number): string => {
+  const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
+
+  let output = '';
+
+  for (let i = 0; i < len; i++) {
+    output += chars[Math.floor(Math.random() * chars.length)];
+  }
+
+  return output;
+};
+
+// This is literally the hackiest code I have ever written but it works and it's
+// not important anyway.
+const parseBody = (input: string) => {
+  const obj = {};
+
+  input
+    .replace(/\r/g, '')
+    .split(/------.+/g)
+    .slice(1)
+    .forEach(item => {
+      const rows = item.split('\n');
+      const key = rows[1].split('"')[1];
+      const isImage = [ 'photo', 'idScan' ].includes(key);
+
+      if (!key || isImage) {
+        return;
+      }
+
+      const value =  rows.slice(2).join('\n').trim();
+      obj[key] = value;
+    });
+
+  return obj;
+};
+
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: '100mb'
+    }
+  }
+};
+
+export default async function addEmployee(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({
+      code: 405,
+      message: 'Only POST method is allowed.'
+    });
+  }
+
+  const fields: EmployeeWithAuthCode = parseBody(req.body) as EmployeeWithAuthCode;
+  console.log(fields);
+
+  if (fields.authCode !== SERVER_SECRET) {
+    return res.status(403).json({
+      code: 403,
+      message: 'Incorrect server secret.'
+    });
+  }
+
+  delete fields.authCode;
+
+  const employeeId = randomString(6);
+  const uniqueId = randomString(10);
+
+  const db = fs.existsSync(DB_PATH)
+    ? JSON.parse(fs.readFileSync(DB_PATH, { encoding: 'utf8' }))
+    : [];
+
+  fields.photo = 'https://i.imgur.com/PrgFA6p.jpg';
+  fields.idScan = 'https://crouton.net';
+
+  db.push({
+    employeeId,
+    uniqueId,
+    ...fields
+  });
+
+  fs.writeFileSync(DB_PATH, JSON.stringify(db), { encoding: 'utf8' });
+
+  return res.json({
+    code: 0,
+    message: 'success',
+    data: {
+      employee_id: employeeId,
+      unique_id: uniqueId
+    }
+  });
+};

--- a/pages/employees/[id].tsx
+++ b/pages/employees/[id].tsx
@@ -1,0 +1,89 @@
+import EmployeeData, { Employee } from '@/components/employees/EmployeeData';
+import LoadingSpinner from '@/components/loading-spinner/LoadingSpinner';
+import Meta from '@/components/Meta';
+import Page from '@/components/page/Page';
+
+import { useRouter } from 'next/router';
+import React, { FormEvent, useState } from 'react';
+
+interface ServerResponse {
+  code: number;
+  message: string;
+  data?: Employee;
+}
+
+const EmployeeDataPage = () => {
+  const router = useRouter();
+  const { id } = router.query;
+
+  const [ title, setTitle ] = useState('Server Secret Required');
+  const [ subtitle, setSubtitle ] = useState('Please provide the server secret.');
+
+  const [ employeeData, setEmployeeData ] = useState<null | Employee>(null);
+  const [ secret, setSecret ] = useState('');
+
+  const [ sending, setSending ] = useState(false);
+  const [ error, setError ] = useState('');
+
+  const authorize = async (e: FormEvent) => {
+    e.preventDefault();
+
+    setSending(true);
+    setError('');
+
+    try {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_EMPLOYEE_API_ENDPOINT}/${id}?secret=${secret}`);
+      const json: ServerResponse = await res.json();
+
+      if (json.code === 0) {
+        setEmployeeData(json.data);
+        setSending(false);
+
+        setTitle(`${json.data.lastName}, ${json.data.firstName} ${json.data.middleName || ''}`);
+        setSubtitle(`Employee #${json.data.uniqueId}`);
+        return;
+      }
+
+      setError(json.message ?? 'Internal Server Error');
+      setSending(false);
+    } catch (err) {
+      console.error(err);
+      setError('Internal Server Error');
+    }
+  };
+
+  return (
+    <Page title={title} subtitle={subtitle}>
+      <Meta
+        title={title}
+        description={subtitle}
+        url={`/employees/${id}`}
+      />
+
+      {!employeeData && (
+        <form onSubmit={authorize}>
+          <div className="input-group">
+            <label htmlFor="secret">Server secret:</label>
+            <input
+              type="password"
+              id="secret"
+              name="secret"
+              disabled={sending}
+              onChange={e => setSecret(e.currentTarget.value)}
+            />
+          </div>
+
+          <div className="input-group buttons">
+            <button type="submit" className="single-button" disabled={sending}>Submit</button>
+            {sending && <LoadingSpinner color="#fff" />}
+            {error.length > 0 && <small className="form-error">{error}</small>}
+          </div>
+        </form>
+      )}
+
+      {employeeData && <EmployeeData employee={employeeData} />}
+    </Page>
+  );
+};
+
+export default EmployeeDataPage;

--- a/pages/employees/add.tsx
+++ b/pages/employees/add.tsx
@@ -1,0 +1,52 @@
+import EmployeeForm, { EmployeeDataFormFields, EmployeeDataServerResponse } from '@/components/employees/EmployeeForm';
+import Meta from '@/components/Meta';
+import Page from '@/components/page/Page';
+
+const AddEmployeePage = () => {
+  const send = async (fields: EmployeeDataFormFields): Promise<EmployeeDataServerResponse> => {
+    const data = new FormData();
+    data.append('firstName', fields.firstName);
+
+    if (fields.middleName) {
+      data.append('middleName', fields.middleName);
+    }
+
+    data.append('lastName', fields.lastName);
+    data.append('identification', fields.identification);
+    data.append('id', fields.id);
+    data.append('department', fields.department);
+    data.append('mobile', fields.mobile);
+    data.append('email', fields.email);
+    data.append('bloodGroup', fields.bloodGroup);
+    data.append('dob', fields.dob);
+    data.append('joiningDate', fields.joiningDate);
+    data.append('maritalStatus', fields.maritalStatus);
+    data.append('address', fields.address);
+    data.append('designation', fields.designation);
+    data.append('authCode', fields.authCode);
+    data.append('photo', fields.photo);
+    data.append('idScan', fields.idScan);
+
+    const res = await fetch(process.env.NEXT_PUBLIC_EMPLOYEE_API_ENDPOINT, {
+      method: 'POST',
+      body: data
+    });
+
+    const json: EmployeeDataServerResponse = await res.json();
+    return json;
+  };
+
+  return (
+    <Page title="Add Employee" subtitle="Use this form to add employee data to the database.">
+      <Meta
+        title="Add Employee"
+        description="Add employee data."
+        url="/employees/add"
+      />
+
+      <EmployeeForm send={send} />
+    </Page>
+  );
+};
+
+export default AddEmployeePage;

--- a/styles/base.scss
+++ b/styles/base.scss
@@ -121,7 +121,7 @@ form {
   margin-bottom: 1.5em;
 }
 
-label, input, textarea {
+label, input, textarea, select {
   display: block;
 }
 
@@ -131,7 +131,7 @@ label {
   margin-bottom: 5px;
 }
 
-input, textarea {
+input, textarea, select {
   box-sizing: border-box;
   width: 100%;
   border: 0;
@@ -207,6 +207,34 @@ button {
     font-size: 1.5em;
     vertical-align: middle;
     margin-right: 0.5em;
+  }
+}
+
+.table-container {
+  border: 1px solid $background-secondary;
+
+  .row {
+    border-bottom: 1px solid $background-secondary;
+
+    &:last-child {
+      border-bottom: 0;
+    }
+
+    .column {
+      display: inline-block;
+      padding: 10px;
+      border-right: 1px solid $background-secondary;
+
+      &:last-child {
+        border-right: 0;
+      }
+
+      &.key {
+        width: 150px;
+        font-weight: 700;
+        background: $background-secondary
+      }
+    }
   }
 }
 

--- a/temp/.gitignore
+++ b/temp/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
I suggest that these routes are either protected using htpasswd or there's a more secure way to process the data on the API side.
- `/employees/:id`
- `/employees/add`

Form that gets sent to the server on the add form: https://github.com/jozsefsallai/xkern/blob/e3256fea00b7f0272b57a1965e434764affa854a/pages/employees/add.tsx#L7
(`photo` and `idScan` are files here)

`/employees/:id` expects the following fields in JSON from the server:
- `status` (number)
- `message` (string)
- `data` (Employee) - https://github.com/jozsefsallai/xkern/blob/e3256fea00b7f0272b57a1965e434764affa854a/components/employees/EmployeeData.tsx#L4
(`photo` and `idScan` are URLs to the uploaded images here)